### PR TITLE
Keep proof guidance in dedicated skill

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -1211,27 +1211,6 @@ pub fn binary_search(arr : ArrayView[Int], value : Int) -> SearchIndex {
     } else {
       InsertionPoint(i)
     }
-  } where {
-    proof_invariant: 0 <= i && i <= j && j <= len,
-    proof_invariant: i == 0 || arr[i - 1] < value,
-    proof_invariant: j == len || arr[j] >= value,
-    proof_reasoning: (
-      #|For a sorted array, the boundary invariants are witnesses:
-      #|  - `arr[i-1] < value` implies all arr[0..i) < value (by sortedness)
-      #|  - `arr[j] >= value` implies all arr[j..len) >= value (by sortedness)
-      #|
-      #|Preservation proof:
-      #|  - When arr[h] < value: new_i = h+1, and arr[new_i - 1] = arr[h] < value ✓
-      #|  - When arr[h] >= value: new_j = h, and arr[new_j] = arr[h] >= value ✓
-      #|
-      #|Termination: j - i decreases each iteration (h is strictly between i and j)
-      #|
-      #|Correctness at exit (i == j):
-      #|  - By invariants: arr[0..i) < value and arr[i..len) >= value
-      #|  - So if value exists, it can only be at index i
-      #|  - If arr[i] != value, then value is absent and i is the insertion point
-      #|
-    ),
   }
 }
 
@@ -1249,34 +1228,6 @@ test "functional for loop control flow" {
 
 You are *STRONGLY ENCOURAGED* to use functional `for` loops instead of imperative loops
 *WHENEVER POSSIBLE*, as they are easier to read and reason about.
-
-### Loop Invariants with `where` Clause
-
-The `where` clause attaches **machine-checkable invariants** and **human-readable reasoning** to functional `for` loops. This enables formal verification thinking while keeping the code executable. Note for trivial loops, you are encouraged to convert it into `for .. in` so no reasoning is needed.
-
-**Syntax:**
-```mbt nocheck
-for ... {
-  ...
-} where {
-  invariant : <boolean_expr>,   // checked at runtime in debug builds
-  invariant : <boolean_expr>,   // multiple invariants allowed
-  reasoning : <string>         // documentation for proof sketch
-}
-```
-
-**Writing Good Invariants:**
-
-1. **Make invariants checkable**: Invariants must be valid MoonBit boolean expressions using loop variables and captured values.
-
-2. **Use boundary witnesses**: For properties over ranges (e.g., "all elements in arr[0..i) satisfy P"), check only boundary elements. For sorted arrays, `arr[i-1] < value` implies all `arr[0..i) < value`.
-
-3. **Handle edge cases with `||`**: Use patterns like `i == 0 || arr[i-1] < value` to handle boundary conditions where the check would be out of bounds.
-
-4. **Cover three aspects in reasoning**:
-   - **Preservation**: Why each `continue` maintains the invariants
-   - **Termination**: Why the loop eventually exits (e.g., a decreasing measure)
-   - **Correctness**: Why the invariants at exit imply the desired postcondition
 
 ## Label and Optional Parameters
 


### PR DESCRIPTION
## Summary

- remove `proof_invariant` and `proof_reasoning` annotations from the general functional-loop example
- remove the duplicated loop-invariant tutorial from the general MoonBit guide
- leave proof-specific loop guidance in the dedicated `moonbit-proof` skill

## Verification

- verified the remaining functional-loop example with `moon run -d`
- confirmed the general guide no longer contains proof loop annotations or proof-specific `where` clauses
- ran `git diff --check`

The bundled skill validator could not start because PyYAML is not installed in its environment.